### PR TITLE
Add github build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,5 +11,7 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
+      - name: Set gradle execution rights
+        run: chmod +x ./src/android_app/gradlew
       - name: Build the app
-        run: ./gradlew build
+        run: cd ./src/android_app/ && ./gradlew assembleDebug # gradlew reports different options

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Build the app
+        run: ./gradlew build


### PR DESCRIPTION
Travis now uses a credit system and these credits are not automatically replenished for public open-source repos. Thus we have to change to github actions.